### PR TITLE
Introduced configurability to work with Chat rooms 

### DIFF
--- a/lib/jabber/bot.rb
+++ b/lib/jabber/bot.rb
@@ -188,7 +188,7 @@ module Jabber
 
       presence(@config[:presence], @config[:status], @config[:priority])
 
-      deliver(@config[:master], "#{@config[:name]} reporting for duty.")
+      deliver(@config[:master], (@config[:startup_message] || "NAME reporting for duty.").gsub("NAME", @config[:name]))
 
       start_listener_thread
     end

--- a/lib/jabber/bot.rb
+++ b/lib/jabber/bot.rb
@@ -95,6 +95,9 @@ module Jabber
       # Default to asking about unknown commands.
       @config[:misunderstood_message] = @config[:misunderstood_message].nil? ? true : @config[:misunderstood_message]
 
+      # Add the help command
+      # You can specify a custom regex for this command with the ':help_regex'
+      # configuration setting.
       add_command(
         :syntax      => 'help [<command>]',
         :description => 'Display help for the given command, or all commands' +
@@ -183,6 +186,8 @@ module Jabber
     end
 
     # Connect the bot, making it available to accept commands.
+    # You can specify a custom startup message with the ':startup_message'
+    # configuration setting.
     def connect
       @jabber = Jabber::Simple.new(@config[:jabber_id], @config[:password])
 
@@ -344,6 +349,10 @@ module Jabber
     # found, the command parameters are passed on to the callback block, minus
     # the command trigger. If a String result is present it is delivered to the
     # sender.
+    #
+    # If an unkown command is found, the bot will default to displaying the
+    # help message.  You can disable this by setting the configuration
+    # setting ':misunderstood_message' to false.
     #
     # If the bot has not been made public, commands from anyone other than the
     # bot master(s) will be silently ignored.

--- a/lib/jabber/bot.rb
+++ b/lib/jabber/bot.rb
@@ -99,7 +99,7 @@ module Jabber
         :syntax      => 'help [<command>]',
         :description => 'Display help for the given command, or all commands' +
             ' if no command is specified',
-        :regex => /^help(\s+?.+?)?$/,
+        :regex => @config[:help_regex] || /^help(\s+?.+?)?$/,
         :alias => [ :syntax => '? [<command>]', :regex  => /^\?(\s+?.+?)?$/ ],
         :is_public => @config[:is_public]
       ) { |sender, message| help_message(sender, message) }

--- a/lib/jabber/bot.rb
+++ b/lib/jabber/bot.rb
@@ -92,6 +92,9 @@ module Jabber
 
       @commands = { :spec => [], :meta => {} }
 
+      # Default to asking about unknown commands.
+      @config[:misunderstood_message] = @config[:misunderstood_message].nil? ? true : @config[:misunderstood_message]
+
       add_command(
         :syntax      => 'help [<command>]',
         :description => 'Display help for the given command, or all commands' +
@@ -359,15 +362,17 @@ module Jabber
 
               response = command[:callback].call(sender, params)
               deliver(sender, response) unless response.nil?
-              
+
               return
             end
           end
         end
 
-        response = "I don't understand '#{message.strip}' Try saying 'help' " +
-            "to see what commands I understand."
-        deliver(sender, response)
+        if @config[:misunderstood_message]
+          response = "I don't understand '#{message.strip}' Try saying 'help' " +
+              "to see what commands I understand."
+          deliver(sender, response)
+        end
       end
     end
 

--- a/lib/jabber/bot.rb
+++ b/lib/jabber/bot.rb
@@ -123,7 +123,7 @@ module Jabber
     # The specified callback block will be triggered when the bot receives a
     # message that matches the given command regex (or an alias regex). The
     # callback block will have access to the sender and the message text (not
-    # including the command itsef), and should either return a String response 
+    # including the command itsef), and should either return a String response
     # or +nil+. If a callback block returns a String response, the response will
     # be delivered to the Jabber id that issued the command.
     #
@@ -147,7 +147,7 @@ module Jabber
     #     :syntax      => 'puts! <string>',
     #     :description => 'Write something to $stdout (without response)',
     #     :regex       => /^puts!\s+.+$/,
-    #     :alias       => [ 
+    #     :alias       => [
     #       { :syntax => 'p! <string>', :regex => /^p!\s+.+$/ },
     #       { :syntax => '! <string>', :regex => /^!\s+/.+$/ }
     #     ]


### PR DESCRIPTION
Hey,

I made some changes to introduce some extra configurability that I needed to get this to work with a chat room, specifically http://partychapp.appspot.com/.  The changes are non-intrusive, and should add some useful flexibility.  

The ':startup_message' setting is just for fun, but the ':misunderstood_message' and ':help_regex' are required to get a bot working in the chat room.

Thanks,

-nick
