### PR TITLE
Commands can have several parameters

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -43,8 +43,8 @@ are created by defining commands powered by regular expressions and Ruby.
   bot.add_command(
     :syntax      => 'puts <string>',
     :description => 'Write something to $stdout',
-    :regex       => /^puts\s+.+$/,
-    :alias       => [ :alias => 'p <string>', :regex => /^p\s+.+$/ ],
+    :regex       => /^puts\s+(.+)$/,
+    :alias       => [ :alias => 'p <string>', :regex => /^p\s+(.+)$/ ],
     :is_public   => true
   ) do |sender, message|
     puts "#{sender} says '#{message}'"

--- a/lib/jabber/bot.rb
+++ b/lib/jabber/bot.rb
@@ -328,7 +328,7 @@ module Jabber
           # Thank you, Hash.sort
           command = command[1]
 
-          if !command[:is_alias] && (command[:is_public] || master? sender)
+          if !command[:is_alias] && (command[:is_public] || master?(sender))
             command[:syntax].each { |syntax| help_message += "#{syntax}\n" }
             help_message += "  #{command[:description]}\n\n"
           end

--- a/lib/jabber/bot.rb
+++ b/lib/jabber/bot.rb
@@ -82,7 +82,7 @@ module Jabber
 
       @config[:is_public] ||= false
 
-      if @config[:name].nil? or @config[:name].length == 0
+      if @config[:name].nil? || @config[:name].length == 0
         @config[:name] = @config[:jabber_id].sub(/@.+$/, '')
       end
 
@@ -312,7 +312,7 @@ module Jabber
     # Commands are sorted alphabetically by name, and are displayed according
     # to the bot's and the commands's _public_ attribute.
     def help_message(sender, command_name) #:nodoc:
-      if command_name.nil? or command_name.length == 0
+      if command_name.nil? || command_name.length == 0
         # Display help for all commands
         help_message = "I understand the following commands:\n\n"
 
@@ -320,7 +320,7 @@ module Jabber
           # Thank you, Hash.sort
           command = command[1]
 
-          if !command[:is_alias] and (command[:is_public] or master? sender)
+          if !command[:is_alias] && (command[:is_public] || master? sender)
             command[:syntax].each { |syntax| help_message += "#{syntax}\n" }
             help_message += "  #{command[:description]}\n\n"
           end
@@ -357,9 +357,9 @@ module Jabber
     def parse_command(sender, message) #:nodoc:
       is_master = master? sender
 
-      if @config[:is_public] or is_master
+      if @config[:is_public] || is_master
         @commands[:spec].each do |command|
-          if command[:is_public] or is_master
+          if command[:is_public] || is_master
             unless (message.strip =~ command[:regex]).nil?
               params = nil
 

--- a/sample/sample.rb
+++ b/sample/sample.rb
@@ -50,7 +50,7 @@ bot = Jabber::Bot.new(config)
 bot.add_command(
   :syntax      => 'puts <string>',
   :description => 'Write something to $stdout',
-  :regex       => /^puts\s+.+$/
+  :regex       => /^puts\s+(.+)$/
 ) do |sender, message|
   puts "#{sender} says '#{message}'"
   "'#{message}' written to $stdout"
@@ -60,7 +60,7 @@ end
 bot.add_command(
   :syntax      => 'puts! <string>',
   :description => 'Write something to $stdout',
-  :regex       => /^puts!\s+.+$/
+  :regex       => /^puts!\s+(.+)$/
 ) do |sender, message|
   puts "#{sender} says '#{message}'"
   nil


### PR DESCRIPTION
Hi Brett,

That is the new version of my pull request, to add the ability to have several parameters for commands you add to the bot.
- The first commit is a cleanup, to replace and/or with &&/||, because they are not synonyms. See [this article for an explanation](http://avdi.org/devblog/2010/08/02/using-and-and-or-in-ruby/). This can avoid subtle bugs :)
- The second commit is the new feature. The trick is done around the [line 363](https://github.com/v0n/jabber-bot/commit/730fa525440871a1982a6158888394028e67a4ec#L1L363). As we've talked about in the last pull request, the only thing to do is to add groups (expression between parenthesis) in the command regex, to allow several parameters in the callback function (`"p Hello world!".match(/^p\s+(.*)$/).captures # => ["Hello world!"]` shows the idea). By the way, the piece of code to scan the message is a bit cleaner.

Here's an example of command with this feature:

```
add_command(
  :syntax      => 'rand_in <min> <max>',
  :description => 'Produce a random number between <min> and <max>',
  :regex       => /^rand_in\s+(\d+)\s+(\d+)$/,
  :is_public   => true
) do |sender, params|
  min, max = params.map { |d| d.to_i }
  rand(max - min) + min
end
```

So that could be used like this: `rand_in 30 50 # => 42`.

I think it is useful (for a project, I use something like `email recipient@somewhere.com Body of the message...`), and in my opinion, adding groups to the regex makes the command more readable and easier to handle.

Thanks,
Vivien.
