### PR TITLE
Fix for individual command helper.

### DIFF
--- a/lib/jabber/bot.rb
+++ b/lib/jabber/bot.rb
@@ -191,21 +191,6 @@ module Jabber
       end
     end
 
-    def add_command_invisible(command, &callback)
-      name = command_name(command[:syntax])
-
-      # Add the command meta - used in the 'help' command response.
-      # add_command_meta(name, command) !!Comented out because you do not want the command to show in help command response. SL
-
-      # Add the command spec - used for parsing incoming commands.
-      add_command_spec(command, callback)
-
-      # Add any command aliases to the command meta and spec // Because of this, we don't want to add aliases to invisible commands. SL
-      # unless command[:alias].nil?
-      #   command[:alias].each { |a| add_command_alias(name, a, callback) }
-      # end
-    end
-
     # Connect the bot, making it available to accept commands.
     # You can specify a custom startup message with the ':startup_message'
     # configuration setting.

--- a/lib/jabber/bot.rb
+++ b/lib/jabber/bot.rb
@@ -100,7 +100,7 @@ module Jabber
         :syntax      => 'help [<command>]',
         :description => 'Display help for the given command, or all commands' +
             ' if no command is specified',
-        :regex => /^help(\s+?.+?)?$/,
+        :regex => /^help\s?(.+?)?$/,
         :alias => [ :syntax => '? [<command>]', :regex  => /^\?(\s+?.+?)?$/ ],
         :is_public => @config[:is_public]
       ) { |sender, message| help_message(sender, message) }

--- a/lib/jabber/bot.rb
+++ b/lib/jabber/bot.rb
@@ -191,6 +191,21 @@ module Jabber
       end
     end
 
+    def add_command_invisible(command, &callback)
+      name = command_name(command[:syntax])
+
+      # Add the command meta - used in the 'help' command response.
+      # add_command_meta(name, command) !!Comented out because you do not want the command to show in help command response. SL
+
+      # Add the command spec - used for parsing incoming commands.
+      add_command_spec(command, callback)
+
+      # Add any command aliases to the command meta and spec // Because of this, we don't want to add aliases to invisible commands. SL
+      # unless command[:alias].nil?
+      #   command[:alias].each { |a| add_command_alias(name, a, callback) }
+      # end
+    end
+
     # Connect the bot, making it available to accept commands.
     # You can specify a custom startup message with the ':startup_message'
     # configuration setting.


### PR DESCRIPTION
Regex was returning ' <command>' instead of '<command>', therefore preventing the single command help lookup from working.
